### PR TITLE
fixes: prod deployment for config variables

### DIFF
--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -10,7 +10,7 @@ const CONFIGURATIONS = {
     },
     APP_URL: import.meta.env.VITE_APP_URL || process.env.VITE_APP_URL,
     get APP_URL_CLEAN() {
-        return this.APP_URL.replace('https://', '').replace('http://', '').replace(/\/$/, '');
+        return this.APP_URL ? this.APP_URL.replace('https://', '').replace('http://', '').replace(/\/$/, '') : '';
     }
 };
  


### PR DESCRIPTION
This pull request includes a small change to the `src/configs/index.ts` file. The change ensures that the `APP_URL_CLEAN` getter handles cases where `APP_URL` is undefined or null by returning an empty string instead of potentially causing an error.