### PR TITLE
fixes: prod deployment for config variables v2

### DIFF
--- a/src/hooks/getUsernameLink.ts
+++ b/src/hooks/getUsernameLink.ts
@@ -1,7 +1,7 @@
-import { APP_URL } from "../configs";
+import { APP_URL_CLEAN } from "../configs";
 
 export function getUsernameLink(username: string): string {
-  const baseUrl = APP_URL;
+  const baseUrl = APP_URL_CLEAN;
 
   return `${baseUrl}/${username}`;
 }

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -16,6 +16,7 @@ import WhisprSwipeCard from '../molecules/WhisprSwipeCard';
 import FilterControls from '../molecules/FilterControl';
 import ViewWhisprModal from '../molecules/ViewWhisprModal';
 import { toast } from 'react-hot-toast';
+import { FUNCTIONS } from '../configs';
 
 const DashboardPage: React.FC = () => {
   const { user, profile } = useAuth();
@@ -202,21 +203,27 @@ const DashboardPage: React.FC = () => {
     // Open view modal with share intent
     setSelectedWhispr(whispr);
     setViewModalOpen(true);
-    
-    // After a slight delay, trigger the share function in the modal
-    // This is handled within the ViewWhisprModal component
   };
   
   // Handle delete whispr - using the new modal confirmation
   const handleDelete = async (whisprId: string) => {
     try {
-      const { error } = await supabase
-        .from('whisprs')
-        .delete()
-        .eq('id', whisprId);
+      // Call the edge function to delete the whispr
+      const response = await fetch(FUNCTIONS.DELETE_USER, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ 
+          whispr_id: whisprId,
+          user_id: user?.id
+        }),
+      });
       
-      if (error) {
-        console.error('Error deleting whispr:', error);
+      const data = await response.json();
+      
+      if (!response.ok) {
+        console.error('Error deleting whispr:', data.error);
         toast.error('Failed to delete whispr');
         return;
       }

--- a/src/pages/PublicProfilePage.tsx
+++ b/src/pages/PublicProfilePage.tsx
@@ -5,7 +5,7 @@ import { toast } from 'react-hot-toast';
 import Logo from '../atoms/Logo';
 import FooterSimple from '../organisms/Shared/FooterSimple';
 import WhisprSubmissionForm from '../organisms/PublicProfile/WhisprSubmissionForm';
-import CONFIGURATIONS from '../configs';
+import CONFIGURATIONS, { FUNCTIONS } from '../configs';
 
 interface PublicProfileData {
   username: string;
@@ -60,7 +60,7 @@ const PublicProfilePage: React.FC = () => {
   // Update profile views when page loads
   const updateProfileViews = async (username: string) => {
     try {
-      const response = await fetch(CONFIGURATIONS.FUNCTIONS.UPDATE_PROFILE_VIEWS, {
+      const response = await fetch(FUNCTIONS.UPDATE_PROFILE_VIEWS, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username })

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -8,7 +8,7 @@ import ProfileForm from '../organisms/Profile/ProfileForm';
 import EmailSettings from '../organisms/Settings/EmailSettings';
 import AccountManagement from '../organisms/Settings/AccountManagement';
 import { useNavigate } from 'react-router-dom';
-import CONFIGURATIONS from '../configs';
+import { FUNCTIONS } from '../configs';
 
 const SettingsPage: React.FC = () => {
   const { user, profile, refreshProfile, signOut } = useAuth();
@@ -245,7 +245,7 @@ const SettingsPage: React.FC = () => {
 
 
       const response = await fetch(
-        CONFIGURATIONS.FUNCTIONS.DELETE_USER,
+        FUNCTIONS.DELETE_USER,
         {
           headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
This pull request refactors the usage of configuration constants across multiple files and updates the logic for handling API calls to improve maintainability and consistency. The most important changes include replacing `CONFIGURATIONS.FUNCTIONS` with `FUNCTIONS` for API endpoints, updating the deletion logic for `whisprs` to use a centralized edge function, and cleaning up unused code.

### Refactoring configuration constants:

* Replaced `CONFIGURATIONS.FUNCTIONS` with `FUNCTIONS` across multiple files (`DashboardPage.tsx`, `PublicProfilePage.tsx`, `SettingsPage.tsx`) to streamline the use of API endpoint constants. [[1]](diffhunk://#diff-ba7b34186baa344570006a41132f410f1799d2a10b839956d7584ddeeafbc734R19) [[2]](diffhunk://#diff-8ddcec73eaf654c710625c9113441bd31b83401bc043f70c8da6f87ae03bd139L8-R8) [[3]](diffhunk://#diff-dd5b1d7b1fd39b023ef1f9c701677811e53e959ec0294e5bfd77484cf339a624L11-R11) [[4]](diffhunk://#diff-dd5b1d7b1fd39b023ef1f9c701677811e53e959ec0294e5bfd77484cf339a624L248-R248)

### API call improvements:

* Updated the `handleDelete` function in `DashboardPage.tsx` to use a centralized edge function (`FUNCTIONS.DELETE_USER`) for deleting `whisprs`, replacing the previous Supabase query. This change improves modularity and error handling.
* Updated the `updateProfileViews` function in `PublicProfilePage.tsx` to use `FUNCTIONS.UPDATE_PROFILE_VIEWS` for consistency with other API calls.

### Minor cleanup:

* Replaced `APP_URL` with `APP_URL_CLEAN` in `getUsernameLink.ts` to reflect a cleaner base URL.