### PR TITLE
whispr@beta v0.2 stable version fixes share api issue

### DIFF
--- a/src/hooks/useShareLink.ts
+++ b/src/hooks/useShareLink.ts
@@ -35,16 +35,18 @@ export const useShareLink = () => {
         try {
             setShareError(null);
 
+            const fixedUrl = url.replace(/(https?:\/\/[^\/]+)\/\1/, '$1');
+
             // Check if Web Share API is available
             if (navigator.share) {
                 await navigator.share({
                     title,
                     text,
-                    url
+                    url: fixedUrl
                 });
                 return true;
             } else if (copyFallback) {
-                return await copyToClipboard(url);
+                return await copyToClipboard(fixedUrl);
             } else {
                 setShareError('Sharing not supported on this device');
                 setTimeout(() => setShareError(null), 3000);


### PR DESCRIPTION
This pull request includes a small improvement to the `useShareLink` hook. The change ensures that duplicate domain segments in the URL are removed before sharing or copying, improving the reliability of the shared link.