### PR TITLE
whispr@beta v0.2 stable version fixes share api issue v3

### DIFF
--- a/src/hooks/useShareLink.ts
+++ b/src/hooks/useShareLink.ts
@@ -34,19 +34,19 @@ export const useShareLink = () => {
 
         try {
             setShareError(null);
-
-            const fixedUrl = url.replace(/(https?:\/\/[^/]+)\/\1/, '$1');
-
+            if (!url.startsWith('http://') && !url.startsWith('https://')) {
+                url = 'https://' + url;
+            }
             // Check if Web Share API is available
             if (navigator.share) {
                 await navigator.share({
                     title,
                     text,
-                    url: fixedUrl
+                    url: url
                 });
                 return true;
             } else if (copyFallback) {
-                return await copyToClipboard(fixedUrl);
+                return await copyToClipboard(url);
             } else {
                 setShareError('Sharing not supported on this device');
                 setTimeout(() => setShareError(null), 3000);


### PR DESCRIPTION
This pull request updates the `useShareLink` hook to improve URL handling and ensure compatibility with the Web Share API. The key change is the addition of a check to prepend `https://` to URLs that do not already include a protocol.

### URL handling improvements:
* In `src/hooks/useShareLink.ts`, added a check to prepend `https://` to URLs that do not start with `http://` or `https://`. This ensures that the URLs are properly formatted before being shared or copied.
* Removed the previous logic that replaced duplicate domain segments in the URL, as it is no longer necessary with the updated handling.