### PR TITLE
Fix username debounce

### DIFF
--- a/src/hooks/useSetting.ts
+++ b/src/hooks/useSetting.ts
@@ -25,6 +25,8 @@ export const useSetting = () => {
 
     // Keep track of previous avatar URL to detect changes
     const prevAvatarUrlRef = useRef('');
+    // Store debounce timer for username availability check
+    const usernameDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     // Initialize form with profile data
     useEffect(() => {
@@ -91,12 +93,14 @@ export const useSetting = () => {
     const handleUsernameChange = (value: string) => {
         setUsername(value);
 
-        // Debounce check
-        const timer = setTimeout(() => {
+        // Debounce check - clear previous timer then set a new one
+        if (usernameDebounceRef.current) {
+            clearTimeout(usernameDebounceRef.current);
+        }
+
+        usernameDebounceRef.current = setTimeout(() => {
             checkUsernameAvailability(value);
         }, 500);
-
-       clearTimeout(timer);
     };
 
     // Save profile changes


### PR DESCRIPTION
## Summary
- fix debounced username availability check by using a ref to store the timeout

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing React type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6845a6fefba0832daf03bc88cc0e461a