### PR TITLE
fix: add protocol validation for auth redirects + troubleshooting guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
-# App Configuration
-NEXT_PUBLIC_APP_URL=http://10.82.37.101:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # Supabase Configuration
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url_here

--- a/context/auth/AuthContext.tsx
+++ b/context/auth/AuthContext.tsx
@@ -209,7 +209,12 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       console.log("AuthProvider: Sending magic link to:", email);
       
       // Get the redirect URL from config or fallback to window.location.origin (client-side only)
-      const redirectUrl = CONFIGURATIONS.APP_URL || (typeof window !== 'undefined' ? window.location.origin : '');
+      let redirectUrl = CONFIGURATIONS.APP_URL || (typeof window !== 'undefined' ? window.location.origin : '');
+      
+      // Ensure the URL has a protocol
+      if (redirectUrl && !redirectUrl.startsWith('http://') && !redirectUrl.startsWith('https://')) {
+        redirectUrl = `https://${redirectUrl}`;
+      }
       
       const { error } = await supabase.auth.signInWithOtp({
         email,

--- a/lib/client/auth.ts
+++ b/lib/client/auth.ts
@@ -40,10 +40,16 @@ export async function signInWithMagicLink(email: string, redirectUrl: string): P
     
     const supabase = createClient();
     
+    // Ensure the redirect URL has a protocol
+    let finalRedirectUrl = redirectUrl;
+    if (finalRedirectUrl && !finalRedirectUrl.startsWith('http://') && !finalRedirectUrl.startsWith('https://')) {
+      finalRedirectUrl = `https://${finalRedirectUrl}`;
+    }
+    
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {
-        emailRedirectTo: redirectUrl,
+        emailRedirectTo: finalRedirectUrl,
       },
     });
 


### PR DESCRIPTION
This pull request focuses on improving the handling of application URLs, specifically ensuring that redirect URLs used for authentication always include a protocol (`http://` or `https://`). This helps prevent potential issues with invalid URLs during the sign-in flow. Additionally, the example environment configuration file has been updated for local development.

**Authentication URL Handling Improvements:**

* Added logic in `context/auth/AuthContext.tsx` to ensure the magic link redirect URL always starts with a protocol, defaulting to `https://` if missing.
* Added similar protocol enforcement for the redirect URL in `lib/client/auth.ts` during the sign-in process.

**Configuration Updates:**

* Updated `.env.example` to set `NEXT_PUBLIC_APP_URL` to `http://localhost:3000` for easier local development.